### PR TITLE
Don't mix config with docs.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export default function init (config) {
       ignore: {
         tags: []
       }
-    }, config || {});
+    }, config.docs || {});
 
     const docsPath = rootDoc.docsPath;
 


### PR DESCRIPTION
The way `config` is merged into the rootDocs now results in *invalid* properties in the resulting `swagger.json`. This change will also open the door to more configuration (for things like overriding the definition of operation 'id' fields.).

Consider this a 'request for discussion'. If you agree, I'll comb through and fix any tests and documentation.