### PR TITLE
Make sure nested path params are in swagger style.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,8 +94,9 @@ export default function init (config) {
       }
 
       const pathObj = rootDoc.paths;
-      const withIdKey = `/${path}/{${service.id || 'id'}}`;
-      const withoutIdKey = `/${path}`;
+      const swaggerPath = path.replace(/\/:([^\/]+)/g, '/{$1}')
+      const withIdKey = `/${swaggerPath}/{${service.id || 'id'}}`;
+      const withoutIdKey = `/${swaggerPath}`;
       const securities = doc.securities || [];
 
       if (typeof pathObj[withoutIdKey] === 'undefined') {


### PR DESCRIPTION
When you add a service that has params in the path, all the params should get the `/{myparam}/` style in the path key, not `/:myparam/`.

Example:

```js
app.use('/my/service/:hasIds/in/the/:path/whoops', new Service())
```

We want that to get into the docs like:

```js
{
  paths: {
    ['/my/service/{hasIds}/in/the/{path}/whoops']: {
      // ...
    }
  }
}
```