### PR TITLE
Add path parameter support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,14 +94,13 @@ export default function init (config) {
       }
 
       const pathObj = rootDoc.paths;
-      const withIdKey = `/${path}/{${service.id || 'id'}}`;
-      const withoutIdKey = `/${path}`;
+      const swaggerPath = path.replace(/\/:([^/]+)/g, '/{$1}');
+      const withIdKey = `/${swaggerPath}/{${service.id || 'id'}}`;
+      const withoutIdKey = `/${swaggerPath}`;
       const securities = doc.securities || [];
-      
       if (typeof doc.definition !== 'undefined') {
         rootDoc.definitions[tag] = doc.definition;
       }
-
       if (typeof doc.definitions !== 'undefined') {
         rootDoc.definitions = Object.assign(rootDoc.definitions, doc.definitions);
       }
@@ -115,7 +114,7 @@ export default function init (config) {
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
           security: securities.indexOf('find') > -1 ? security : {}
-        });
+        }, swaggerPath);
       }
 
       // GET
@@ -139,7 +138,7 @@ export default function init (config) {
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
           security: securities.indexOf('get') > -1 ? security : {}
-        });
+        }, swaggerPath);
       }
 
       // CREATE
@@ -157,7 +156,7 @@ export default function init (config) {
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
           security: securities.indexOf('create') > -1 ? security : {}
-        });
+        }, swaggerPath);
       }
 
       // UPDATE
@@ -181,7 +180,7 @@ export default function init (config) {
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
           security: securities.indexOf('update') > -1 ? security : {}
-        });
+        }, swaggerPath);
       }
 
       // PATCH
@@ -205,7 +204,7 @@ export default function init (config) {
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
           security: securities.indexOf('patch') > -1 ? security : {}
-        });
+        }, swaggerPath);
       }
 
       // REMOVE
@@ -224,7 +223,7 @@ export default function init (config) {
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
           security: securities.indexOf('remove') > -1 ? security : {}
-        });
+        }, swaggerPath);
       }
 
       rootDoc.paths = pathObj;

--- a/src/utils.js
+++ b/src/utils.js
@@ -57,7 +57,25 @@ export function tag (name, options = {}) {
   };
 }
 
-export function operation (method, service, defaults = {}) {
+function addPathParameters (swaggerPath, parameters) {
+  var paramRgxp = /\{([^}]+)\}\//g;
+  var match;
+  while ((match = paramRgxp.exec(swaggerPath)) !== null) {
+    parameters.push({
+      in: 'path',
+      name: match[1],
+      type: 'string',
+      required: true,
+      description: match[1] + ' parameter'
+    });
+  }
+}
+
+export function operation (method, service, defaults, swaggerPath) {
+  if (!defaults) defaults = {};
+  if (!defaults.parameters) defaults.parameters = [];
+  if (swaggerPath) addPathParameters(swaggerPath, defaults.parameters);
+
   const operation = Object.assign(service.docs[method] || {}, service[method].docs || {});
 
   operation.parameters = operation.parameters || defaults.parameters || [];


### PR DESCRIPTION
Expose path parameters to swagger: 
`/projects/:projectId/:fubar/sync` becomes `/projects/{projectId}/{fubar}/sync` including

```
parameters: [
   ...
   {in: "path", name: "projectId", type: "string", required: true, description: "projectId parameter"},
   {in: "path", name: "fubar", type: "string", required: true, description: "fubar parameter"}
]
```

It includes the PR #53 which fixes the path-param style
