### PR TITLE
Added version field to swagger-info section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ const app = feathers()
     docsPath: '/docs',
     info: {
       title: 'A test',
-      description: 'A description'
+      description: 'A description',
+      version: '1.0.0'
     }
   }))
   .use('/messages', messageService);
@@ -179,7 +180,8 @@ const app = feathers()
     uiIndex: path.join(__dirname, 'docs.html'),
     info: {
       title: 'A test',
-      description: 'A description'
+      description: 'A description',
+      version: '1.0.0'
     }
   }))
   .use('/messages', messageService);
@@ -362,7 +364,8 @@ const app = feathers()
     docsPath: '/docs',
     info: {
       title: 'A test',
-      description: 'A description'
+      description: 'A description',
+      version: '1.0.0'
     }
   }))
   .use('/api/v1/messages', messageService);
@@ -382,7 +385,8 @@ const app = feathers()
     docsPath: '/docs',
     info: {
       title: 'A test',
-      description: 'A description'
+      description: 'A description',
+      version: '1.0.0'
     }
   }))
   .use('/api/v1/messages', messageService);

--- a/example/app.js
+++ b/example/app.js
@@ -51,7 +51,8 @@ const app = feathers()
     uiIndex,
     info: {
       title: 'A test',
-      description: 'A description'
+      description: 'A description',
+      version: '1.0.0'
     }
   }))
   .use('/messages', messageService);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,7 +20,8 @@ describe('feathers-swagger', () => {
           docsPath: '/docs',
           info: {
             'title': 'A test',
-            'description': 'A description'
+            'description': 'A description',
+            'version': '1.0.0'
           }
         }))
         .use('/messages', memory());


### PR DESCRIPTION
### Summary

The examples and documentation does not include the `info.version` field when configuring the swagger plugin. 

The info field is **REQUIRED** as per https://swagger.io/specification/#info-object-19 . And generates an error when view on for example https://editor.swagger.io .

This PR adds the `version` field to the docs, examples and tests.

PS: There is a bunch more validation errors as well, but this one was easy to fix without knowing too much about FeathersJS :)

Thanks for creating Feathers! :heart: