### PR TITLE
Config contains idType to set default for application

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,7 @@ const init = module.exports = function (config) {
       // Load documentation from service, if available.
       const doc = service.docs;
       const idName = service.id || 'id';
-      const idType = doc.idType || 'integer';
+      const idType = doc.idType || config.idType || 'integer';
       let version = config.versionPrefix ? path.match(config.versionPrefix) : null;
       version = version ? ' ' + version[0] : '';
       const apiPath = path.replace(config.prefix, '');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -118,7 +118,7 @@ exports.operation = function operation (method, service, defaults = {}) {
   operation.produces = operation.produces || defaults.produces || [];
   operation.security = operation.security || defaults.security || {};
   operation.securityDefinitions = operation.securityDefinitions || defaults.securityDefinitions || {};
-      // Clean up
+  // Clean up
   delete service.docs[method]; // Remove `find` from `docs`
 
   return operation;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,13 +16,16 @@ describe('feathers-swagger', () => {
     before(done => {
       const app = feathers()
         .configure(rest())
-        .configure(swagger({
-          docsPath: '/docs',
-          info: {
-            'title': 'A test',
-            'description': 'A description'
-          }
-        }))
+        .configure(
+          swagger({
+            docsPath: '/docs',
+            info: {
+              title: 'A test',
+              description: 'A description'
+            },
+            idType: 'string'
+          })
+        )
         .use('/messages', memory());
 
       server = app.listen(6776, () => done());
@@ -38,6 +41,16 @@ describe('feathers-swagger', () => {
         expect(docs.info.title).to.equal('A test');
         expect(docs.info.description).to.equal('A description');
         expect(docs.paths['/messages']).to.exist;
+      });
+    });
+
+    it('supports id types in config', () => {
+      return rp({
+        url: 'http://localhost:6776/docs',
+        json: true
+      }).then(docs => {
+        const messagesIdParam = docs.paths['/messages/{id}'].get.parameters[0];
+        expect(messagesIdParam.type).to.equal('string');
       });
     });
   });


### PR DESCRIPTION
### Summary

It is possible to define `idType` (by default `"integer"`) per service. This PR adds an optional param `idType` to the root configuration object. The value is the default but can be overwritten.

* The changes are backwards compatible.
* I added the param to the test. I'm not really proud of the way it is, but there is a test. A test setup with multiple instances would be an option in the future, but adds complexity (failed shutdowns, timing, ports).