### PR TITLE
added findQueryParameters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -112,29 +112,44 @@ const init = module.exports = function (config) {
 
       // FIND
       if (typeof service.find === 'function') {
+          let parameters = [
+          {
+            description: "Number of results to return",
+            in: "query",
+            name: "$limit",
+            type: "integer"
+          },
+          {
+            description: "Number of results to skip",
+            in: "query",
+            name: "$skip",
+            type: "integer"
+          },
+          {
+            description: "Property to sort results",
+            in: "query",
+            name: "$sort",
+            type: "string"
+          }
+        ];
+        if (
+          rootDoc.findQueryParameters !== undefined &&
+          rootDoc.findQueryParameters.length > 0
+        ) {
+          parameters = parameters.filter(
+            parametersItem =>
+              !rootDoc.findQueryParameters.find(
+                findQueryParameters =>
+                  parametersItem.name === findQueryParameters.name
+              )
+          );
+          parameters = rootDoc.findQueryParameters.concat(parameters);
+        }
         pathObj[withoutIdKey] = pathObj[withoutIdKey] || {};
         pathObj[withoutIdKey].get = utils.operation('find', service, {
           tags: [tag],
           description: 'Retrieves a list of all resources from the service.',
-          parameters: [{
-            description: 'Number of results to return',
-            in: 'query',
-            name: '$limit',
-            type: 'integer'
-          },
-          {
-            description: 'Number of results to skip',
-            in: 'query',
-            name: '$skip',
-            type: 'integer'
-          },
-          {
-            description: 'Property to sort results',
-            in: 'query',
-            name: '$sort',
-            type: 'string'
-          }
-          ],
+          parameters,
           responses: {
             '200': {
               description: 'success',


### PR DESCRIPTION
Why this PR?
On my work we use feathers-swagger for various services. We wanted to add a few more queries for the find method and also customize the descriptions according to our wishes.
We searched for a long time and did not find any specific way to solve this problem. Therefore, we decided ourselves to add a parameter that allows us to do what we want.

What have I done?
I've added a new Parameter `findQueryParameter`. It is now possible to add new QueryParamters or change the description of the default QueryParamters by adding this Paramter to your swaggerConfig.
In my CodeExample it will look like this:
app.configure(
		swagger({
			findQueryParameters: [
				{
					description: "This is another Description about the query parameter",
					in: "query",
					name: "$limit",
					type: "integer"
				},
				....
			],
			tags: [
				{
					name: "Controllers",
					description: "A Collection of different Controllers"
				}
			],
			paths,
			definitions,
			basePath: "/someService",
			schemes: [
				Config.environment !== "production" && Config.environment !== "staging"
					? "http"
					: "https"
			],
			swagger: "2.0",
			uiIndex: path.join(__dirname, "docs.html"),
			docsPath: "/apidocs"
		})
	);
	console.log("");
};

Please let me know what you think about it.
