### PR TITLE
Only create tags when they have been used

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,6 +84,7 @@ const init = module.exports = function (config) {
       const group = apiPath.split('/');
       const tag = (apiPath.indexOf('/') > -1 ? group[0] : apiPath) + version;
       const model = apiPath.indexOf('/') > -1 ? group[1] : apiPath;
+      let rootTags = [];
       const security = [];
 
       if (rootDoc.security && Array.isArray(rootDoc.security)) {
@@ -134,6 +135,9 @@ const init = module.exports = function (config) {
             type: "string"
           }
         ];
+        const tags = utils.getDocTags('find', doc) || [tag];
+        rootTags = rootTags.concat(tags);
+
         if (
           rootDoc.findQueryParameters !== undefined &&
           rootDoc.findQueryParameters.length > 0
@@ -149,7 +153,7 @@ const init = module.exports = function (config) {
         }
         pathObj[withoutIdKey] = pathObj[withoutIdKey] || {};
         pathObj[withoutIdKey].get = utils.operation('find', service, {
-          tags: [tag],
+          tags: tags,
           description: 'Retrieves a list of all resources from the service.',
           parameters,
           responses: {
@@ -174,9 +178,12 @@ const init = module.exports = function (config) {
 
       // GET
       if (typeof service.get === 'function') {
+        const tags = utils.getDocTags('get', doc) || [tag];
+        rootTags = rootTags.concat(tags);
+
         pathObj[withIdKey] = pathObj[withIdKey] || {};
         pathObj[withIdKey].get = utils.operation('get', service, {
-          tags: [tag],
+          tags: tags,
           description: 'Retrieves a single resource with the given id from the service.',
           parameters: [{
             description: `ID of ${model} to return`,
@@ -210,9 +217,12 @@ const init = module.exports = function (config) {
 
       // CREATE
       if (typeof service.create === 'function') {
+        const tags = utils.getDocTags('create', doc) || [tag];
+        rootTags = rootTags.concat(tags);
+
         pathObj[withoutIdKey] = pathObj[withoutIdKey] || {};
         pathObj[withoutIdKey].post = utils.operation('create', service, {
-          tags: [tag],
+          tags: tags,
           description: 'Creates a new resource with data.',
           parameters: [{ in: 'body',
             name: 'body',
@@ -240,9 +250,12 @@ const init = module.exports = function (config) {
 
       // UPDATE
       if (typeof service.update === 'function') {
+        const tags = utils.getDocTags('update', doc) || [tag];
+        rootTags = rootTags.concat(tags);
+
         pathObj[withIdKey] = pathObj[withIdKey] || {};
         pathObj[withIdKey].put = utils.operation('update', service, {
-          tags: [tag],
+          tags: tags,
           description: 'Updates the resource identified by id using data.',
           parameters: [{
             description: 'ID of ' + model + ' to return',
@@ -282,9 +295,12 @@ const init = module.exports = function (config) {
 
       // PATCH
       if (typeof service.patch === 'function') {
+        const tags = utils.getDocTags('patch', doc) || [tag];
+        rootTags = rootTags.concat(tags);
+
         pathObj[withIdKey] = pathObj[withIdKey] || {};
         pathObj[withIdKey].patch = utils.operation('patch', service, {
-          tags: [tag],
+          tags: tags,
           description: 'Updates the resource identified by id using data.',
           parameters: [{
             description: 'ID of ' + model + ' to return',
@@ -324,9 +340,12 @@ const init = module.exports = function (config) {
 
       // REMOVE
       if (typeof service.remove === 'function') {
+        const tags = utils.getDocTags('remove', doc) || [tag];
+        rootTags = rootTags.concat(tags);
+
         pathObj[withIdKey] = pathObj[withIdKey] || {};
         pathObj[withIdKey].delete = utils.operation('remove', service, {
-          tags: [tag],
+          tags: tags,
           description: 'Removes the resource with id.',
           parameters: [{
             description: 'ID of ' + model + ' to return',
@@ -360,11 +379,13 @@ const init = module.exports = function (config) {
 
       rootDoc.paths = pathObj;
 
-      const existingTag = rootDoc.tags.find(item => item.name === tag);
-      if (!existingTag) {
-        rootDoc.tags.push(utils.tag(tag, doc));
-      } else {
-        Object.assign(existingTag, utils.tag(tag, doc));
+      for (const usedTag of rootTags) {
+        const existingTag = rootDoc.tags.find(item => item.name === usedTag);
+        if (!existingTag) {
+          rootDoc.tags.push(utils.tag(usedTag, doc));
+        } else {
+          Object.assign(existingTag, utils.tag(usedTag, doc));
+        }
       }
     };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -123,3 +123,9 @@ exports.operation = function operation (method, service, defaults = {}) {
 
   return operation;
 };
+
+exports.getDocTags = function getDocTags (method, doc) {
+  if (doc[method] && doc[method].tags) {
+    return doc[method].tags;
+  }
+}


### PR DESCRIPTION
### Summary

Currently feathers-swagger will create a `tag` for any service that has been defined using the URL part for the service. This is fine as a default but it custom tags have been defined then the tag that gets added it's referenced by anything and you end up with a dangling tag. This causes an empty section when rendering the file with e.g. Redoc.

This PR instead only adds this default tag if no tags have been defined for a method in the docs.