### PR TITLE
fix: Default security value should not be an object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -168,7 +168,7 @@ const init = module.exports = function (config) {
           },
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
-          security: securities.indexOf('find') > -1 ? security : {}
+          security: securities.indexOf('find') > -1 ? security : []
         });
       }
 
@@ -204,7 +204,7 @@ const init = module.exports = function (config) {
           },
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
-          security: securities.indexOf('get') > -1 ? security : {}
+          security: securities.indexOf('get') > -1 ? security : []
         });
       }
 
@@ -234,7 +234,7 @@ const init = module.exports = function (config) {
           },
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
-          security: securities.indexOf('create') > -1 ? security : {}
+          security: securities.indexOf('create') > -1 ? security : []
         });
       }
 
@@ -276,7 +276,7 @@ const init = module.exports = function (config) {
           },
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
-          security: securities.indexOf('update') > -1 ? security : {}
+          security: securities.indexOf('update') > -1 ? security : []
         });
       }
 
@@ -318,7 +318,7 @@ const init = module.exports = function (config) {
           },
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
-          security: securities.indexOf('patch') > -1 ? security : {}
+          security: securities.indexOf('patch') > -1 ? security : []
         });
       }
 
@@ -354,7 +354,7 @@ const init = module.exports = function (config) {
           },
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
-          security: securities.indexOf('remove') > -1 ? security : {}
+          security: securities.indexOf('remove') > -1 ? security : []
         });
       }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -116,7 +116,7 @@ exports.operation = function operation (method, service, defaults = {}) {
   operation.tags = operation.tags || defaults.tags || [];
   operation.consumes = operation.consumes || defaults.consumes || [];
   operation.produces = operation.produces || defaults.produces || [];
-  operation.security = operation.security || defaults.security || {};
+  operation.security = operation.security || defaults.security || [];
   operation.securityDefinitions = operation.securityDefinitions || defaults.securityDefinitions || {};
   // Clean up
   delete service.docs[method]; // Remove `find` from `docs`


### PR DESCRIPTION
In the swagger spec, secutiry should be an array of securityDefinition
names and not an object.

This is a small part of #117 by @wnxhaja