### PR TITLE
fix: Remove invalid root level keys from swagger file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,11 @@ const init = module.exports = function (config) {
     app.get(docsPath, function (req, res) {
       res.format({
         'application/json': function () {
+          delete rootDoc.docsPath;
+          delete rootDoc.ignore;
+          delete rootDoc.idType;
+          delete rootDoc.uiIndex;
+
           res.json(rootDoc);
         },
 
@@ -58,6 +63,11 @@ const init = module.exports = function (config) {
               res.redirect('?url=' + encodeURI(config.docsPath));
             }
           } else {
+            delete rootDoc.docsPath;
+            delete rootDoc.ignore;
+            delete rootDoc.idType;
+            delete rootDoc.uiIndex;
+
             res.json(rootDoc);
           }
         }


### PR DESCRIPTION
feathers-swagger adds a number of invalid keys to the root level
document that throw warnings when passing the generated file into e.g
https://editor.swagger.io/.

This is a small part of #117 by @wnxhaja