### PR TITLE
fix: Remove invalid definitions with spaces in the key

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -103,10 +103,6 @@ const init = module.exports = function (config) {
 
       if (typeof doc.definition !== 'undefined') {
         rootDoc.definitions[tag] = doc.definition;
-        rootDoc.definitions[`${tag} list`] = {
-          type: 'array',
-          items: doc.definition
-        };
       }
       if (typeof doc.definitions !== 'undefined') {
         rootDoc.definitions = Object.assign(rootDoc.definitions, doc.definitions);
@@ -156,7 +152,10 @@ const init = module.exports = function (config) {
             '200': {
               description: 'success',
               schema: {
-                '$ref': '#/definitions/' + `${tag} list`
+                type: 'array',
+                items: {
+                  $ref: `#/definitions/${tag}`
+                }
               }
             },
             '500': {


### PR DESCRIPTION
Having a space in a key is invalid for RFC 3986 and throws a warning in
e.g. https://editor.swagger.io. Instead of adding a new definition for a
list of items this PR instead updates the schema to have the array of
items defined inline.