### PR TITLE
chore: Standardise concatenation and object keys

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -9,23 +9,23 @@ messageService.docs = {
   description: 'A service to send and receive messages',
   definitions: {
     messages: {
-      'type': 'object',
-      'required': [
+      type: 'object',
+      required: [
         'text'
       ],
-      'properties': {
-        'text': {
-          'type': 'string',
-          'description': 'The message text'
+      properties: {
+        text: {
+          type: 'string',
+          description: 'The message text'
         },
-        'userId': {
-          'type': 'string',
-          'description': 'The id of the user that send the message'
+        userId: {
+          type: 'string',
+          description: 'The id of the user that send the message'
         }
       }
     },
     'messages list': {
-      'type': 'array'
+      type: 'array'
     }
   }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@ const init = module.exports = function (config) {
               res.sendFile(path.join(modulesRootPath, 'node_modules/swagger-ui-dist/index.html'));
             } else {
               // Set swagger url (needed for default UI)
-              res.redirect('?url=' + encodeURI(config.docsPath));
+              res.redirect(`?url=${encodeURI(config.docsPath)}`);
             }
           } else {
             res.json(rootDoc);
@@ -79,7 +79,7 @@ const init = module.exports = function (config) {
       const idName = service.id || 'id';
       const idType = doc.idType || config.idType || 'integer';
       let version = config.versionPrefix ? path.match(config.versionPrefix) : null;
-      version = version ? ' ' + version[0] : '';
+      version = version ? ` ${version[0]}` : '';
       const apiPath = path.replace(config.prefix, '');
       const group = apiPath.split('/');
       const tag = (apiPath.indexOf('/') > -1 ? group[0] : apiPath) + version;
@@ -120,14 +120,12 @@ const init = module.exports = function (config) {
             in: 'query',
             name: '$limit',
             type: 'integer'
-          },
-          {
+          }, {
             description: 'Number of results to skip',
             in: 'query',
             name: '$skip',
             type: 'integer'
-          },
-          {
+          }, {
             description: 'Property to sort results',
             in: 'query',
             name: '$sort',
@@ -153,17 +151,17 @@ const init = module.exports = function (config) {
           description: 'Retrieves a list of all resources from the service.',
           parameters,
           responses: {
-            '200': {
+            200: {
               description: 'success',
               schema: {
-                '$ref': '#/definitions/' + `${tag} list`
+                $ref: `#/definitions/${tag} list`
               }
             },
-            '500': {
-              description: 'general error'
-            },
-            '401': {
+            401: {
               description: 'not authenticated'
+            },
+            500: {
+              description: 'general error'
             }
           },
           produces: rootDoc.produces,
@@ -186,20 +184,20 @@ const init = module.exports = function (config) {
             type: idType
           }],
           responses: {
-            '200': {
+            200: {
               description: 'success',
               schema: {
-                '$ref': '#/definitions/' + tag
+                $ref: `#/definitions/${tag}`
               }
             },
-            '500': {
-              description: 'general error'
-            },
-            '401': {
+            401: {
               description: 'not authenticated'
             },
-            '404': {
+            404: {
               description: 'not found'
+            },
+            500: {
+              description: 'general error'
             }
           },
           produces: rootDoc.produces,
@@ -214,22 +212,23 @@ const init = module.exports = function (config) {
         pathObj[withoutIdKey].post = utils.operation('create', service, {
           tags: [tag],
           description: 'Creates a new resource with data.',
-          parameters: [{ in: 'body',
+          parameters: [{
+            in: 'body',
             name: 'body',
             required: true,
             schema: {
-              '$ref': '#/definitions/' + tag
+              $ref: `#/definitions/${tag}`
             }
           }],
           responses: {
-            '201': {
+            201: {
               description: 'created'
             },
-            '500': {
-              description: 'general error'
-            },
-            '401': {
+            401: {
               description: 'not authenticated'
+            },
+            500: {
+              description: 'general error'
             }
           },
           produces: rootDoc.produces,
@@ -245,33 +244,34 @@ const init = module.exports = function (config) {
           tags: [tag],
           description: 'Updates the resource identified by id using data.',
           parameters: [{
-            description: 'ID of ' + model + ' to return',
+            description: `ID of ${model} to return`,
             in: 'path',
             required: true,
             name: idName,
             type: idType
-          }, { in: 'body',
+          }, {
+            in: 'body',
             name: 'body',
             required: true,
             schema: {
-              '$ref': '#/definitions/' + tag
+              $ref: `#/definitions/${tag}`
             }
           }],
           responses: {
-            '200': {
+            200: {
               description: 'success',
               schema: {
-                '$ref': '#/definitions/' + tag
+                $ref: `#/definitions/${tag}`
               }
             },
-            '500': {
-              description: 'general error'
-            },
-            '401': {
+            401: {
               description: 'not authenticated'
             },
-            '404': {
+            404: {
               description: 'not found'
+            },
+            500: {
+              description: 'general error'
             }
           },
           produces: rootDoc.produces,
@@ -287,33 +287,34 @@ const init = module.exports = function (config) {
           tags: [tag],
           description: 'Updates the resource identified by id using data.',
           parameters: [{
-            description: 'ID of ' + model + ' to return',
+            description: `ID of ${model} to return`,
             in: 'path',
             required: true,
             name: idName,
             type: idType
-          }, { in: 'body',
+          }, {
+            in: 'body',
             name: 'body',
             required: true,
             schema: {
-              '$ref': '#/definitions/' + tag
+              $ref: `#/definitions/${tag}`
             }
           }],
           responses: {
-            '200': {
+            200: {
               description: 'success',
               schema: {
-                '$ref': '#/definitions/' + tag
+                $ref: `#/definitions/${tag}`
               }
             },
-            '500': {
-              description: 'general error'
-            },
-            '401': {
+            401: {
               description: 'not authenticated'
             },
-            '404': {
+            404: {
               description: 'not found'
+            },
+            500: {
+              description: 'general error'
             }
           },
           produces: rootDoc.produces,
@@ -329,27 +330,27 @@ const init = module.exports = function (config) {
           tags: [tag],
           description: 'Removes the resource with id.',
           parameters: [{
-            description: 'ID of ' + model + ' to return',
+            description: `ID of ${model} to return`,
             in: 'path',
             required: true,
             name: idName,
             type: idType
           }],
           responses: {
-            '200': {
+            200: {
               description: 'success',
               schema: {
-                '$ref': '#/definitions/' + tag
+                $ref: `#/definitions/${tag}`
               }
             },
-            '500': {
-              description: 'general error'
-            },
-            '401': {
+            401: {
               description: 'not authenticated'
             },
-            '404': {
+            404: {
               description: 'not found'
+            },
+            500: {
+              description: 'general error'
             }
           },
           produces: rootDoc.produces,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -60,7 +60,7 @@ exports.property = function property (type, items) {
     if (isUndefined) {
       result.items = { type: exports.getType('INTEGER') };
     } else if (isString) {
-      result.items = { '$ref': '#/definitions/' + items };
+      result.items = { $ref: `#/definitions/${items}` };
     } else {
       result.items = { type: exports.getType(items.key) };
     }
@@ -86,7 +86,7 @@ exports.definition = function definition (model, options = { type: 'object' }) {
 
   const allOf = (options.extends || []).map(item => {
     return {
-      '$ref': '#definitions/' + item
+      $ref: `#definitions/${item}`
     };
   });
 


### PR DESCRIPTION
Standardise some basic formatting:
- string concatenation uses backticks
- strings with double quotes have been replaced with single quotes
- object keys only have quotes where required
- default response codes are ordered numerically