### PR TITLE
fix: Remove invalid securityDefinitions key from operations

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -117,7 +117,6 @@ exports.operation = function operation (method, service, defaults = {}) {
   operation.consumes = operation.consumes || defaults.consumes || [];
   operation.produces = operation.produces || defaults.produces || [];
   operation.security = operation.security || defaults.security || [];
-  operation.securityDefinitions = operation.securityDefinitions || defaults.securityDefinitions || {};
   // Clean up
   delete service.docs[method]; // Remove `find` from `docs`
 


### PR DESCRIPTION
The secirutyDefinitions key should only be persent at the top level, not
for each operation.

https://swagger.io/docs/specification/2-0/authentication/basic-authentication/