### PR TITLE
Add test to validate swagger specification, fix spec errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ messageService.docs = {
           "type": "string",
           "description": "The message text"
         },
-        "useId": {
+        "userId": {
           "type": "string",
           "description": "The id of the user that sent the message"
         }

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ const app = feathers()
     docsPath: '/docs',
     info: {
       title: 'A test',
-      description: 'A description'
+      description: 'A description',
+      version: '1.0.0'
     }
   }))
   .use('/messages', messageService);
@@ -177,7 +178,8 @@ const app = feathers()
     uiIndex: path.join(__dirname, 'docs.html'),
     info: {
       title: 'A test',
-      description: 'A description'
+      description: 'A description',
+      version: '1.0.0'
     }
   }))
   .use('/messages', messageService);
@@ -360,7 +362,8 @@ const app = feathers()
     docsPath: '/docs',
     info: {
       title: 'A test',
-      description: 'A description'
+      description: 'A description',
+      version: '1.0.0'
     }
   }))
   .use('/api/v1/messages', messageService);
@@ -380,7 +383,8 @@ const app = feathers()
     docsPath: '/docs',
     info: {
       title: 'A test',
-      description: 'A description'
+      description: 'A description',
+      version: '1.0.0'
     }
   }))
   .use('/api/v1/messages', messageService);

--- a/example/app.js
+++ b/example/app.js
@@ -25,7 +25,10 @@ messageService.docs = {
       }
     },
     'messages list': {
-      type: 'array'
+      type: 'array',
+      items: {
+        $ref: `#/definitions/messages`
+      }
     }
   }
 };

--- a/example/app.js
+++ b/example/app.js
@@ -50,7 +50,8 @@ const app = express(feathers())
     uiIndex,
     info: {
       title: 'A test',
-      description: 'A description'
+      description: 'A description',
+      version: '1.0.0'
     }
   }))
   .use('/messages', messageService);

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ const init = module.exports = function (config) {
       swagger: '2.0',
       schemes: ['http'],
       tags: [],
-      basePath: '',
+      basePath: '/',
       docsPath: '/docs',
       consumes: ['application/json'],
       produces: ['application/json'],

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -102,7 +102,7 @@ exports.tag = function tag (name, options = {}) {
   return {
     name,
     description: options.description || `A ${name} service`,
-    externalDocs: options.externalDocs || {}
+    externalDocs: options.externalDocs || undefined
   };
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -634,6 +634,12 @@
         "unset-value": "^1.0.0"
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -2121,6 +2127,12 @@
         "mime-types": "^2.1.11"
       }
     },
+    "format-util": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
+      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU=",
+      "dev": true
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -2988,6 +3000,29 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
+    "json-schema-ref-parser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
+      "integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.12.1",
+        "ono": "^4.0.11"
+      },
+      "dependencies": {
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3004,6 +3039,18 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "jsonschema": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
+      "dev": true
+    },
+    "jsonschema-draft4": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jsonschema-draft4/-/jsonschema-draft4-1.0.0.tgz",
+      "integrity": "sha1-8K8gBQVPDwrefqIRhhS2ncUS2GU=",
       "dev": true
     },
     "jsprim": {
@@ -3096,6 +3143,18 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -3593,6 +3652,26 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
+      }
+    },
+    "ono": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
+      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
+      "dev": true,
+      "requires": {
+        "format-util": "^1.0.3"
+      }
+    },
+    "openapi-schema-validation": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/openapi-schema-validation/-/openapi-schema-validation-0.4.2.tgz",
+      "integrity": "sha512-K8LqLpkUf2S04p2Nphq9L+3bGFh/kJypxIG2NVGKX0ffzT4NQI9HirhiY6Iurfej9lCu7y4Ndm4tv+lm86Ck7w==",
+      "dev": true,
+      "requires": {
+        "jsonschema": "1.2.4",
+        "jsonschema-draft4": "^1.0.0",
+        "swagger-schema-official": "2.0.0-bab6bed"
       }
     },
     "optimist": {
@@ -4873,6 +4952,33 @@
         "utfstring": "^2.0.0"
       }
     },
+    "swagger-methods": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.8.tgz",
+      "integrity": "sha512-G6baCwuHA+C5jf4FNOrosE4XlmGsdjbOjdBK4yuiDDj/ro9uR4Srj3OR84oQMT8F3qKp00tYNv0YN730oTHPZA==",
+      "dev": true
+    },
+    "swagger-parser": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-6.0.5.tgz",
+      "integrity": "sha512-UL47eu4+GRm5y+N7J+W6QQiqAJn2lojyqgMwS0EZgA55dXd5xmpQCsjUmH/Rf0eKDiG1kULc9VS515PxAyTDVw==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "json-schema-ref-parser": "^6.0.3",
+        "ono": "^4.0.11",
+        "openapi-schema-validation": "^0.4.2",
+        "swagger-methods": "^1.0.8",
+        "swagger-schema-official": "2.0.0-bab6bed",
+        "z-schema": "^3.24.2"
+      }
+    },
+    "swagger-schema-official": {
+      "version": "2.0.0-bab6bed",
+      "resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
+      "integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0=",
+      "dev": true
+    },
     "swagger-ui": {
       "version": "3.20.8",
       "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-3.20.8.tgz",
@@ -5324,6 +5430,12 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "validator": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
+      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==",
+      "dev": true
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -5527,6 +5639,19 @@
         "flat": "^4.1.0",
         "lodash": "^4.17.11",
         "yargs": "^12.0.5"
+      }
+    },
+    "z-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.25.1.tgz",
+      "integrity": "sha512-7tDlwhrBG+oYFdXNOjILSurpfQyuVgkRe3hB2q8TEssamDHB7BbLWYkYO98nTn0FibfdFroFKDjndbgufAgS/Q==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.7.1",
+        "core-js": "^2.5.7",
+        "lodash.get": "^4.0.0",
+        "lodash.isequal": "^4.0.0",
+        "validator": "^10.0.0"
       }
     },
     "zenscroll": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mocha": "mocha --opts mocha.opts",
     "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- --opts mocha.opts",
     "test": "npm run lint && npm run coverage",
-    "start": "npm run compile && node example/simple/app"
+    "start": "node example/app"
   },
   "semistandard": {
     "sourceType": "module",
@@ -67,6 +67,7 @@
     "mocha": "^6.0.0",
     "request": "^2.88.0",
     "request-promise": "^4.2.4",
-    "semistandard": "^13.0.1"
+    "semistandard": "^13.0.1",
+    "swagger-parser": "^6.0.5"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,10 +1,11 @@
 /* eslint-disable no-unused-expressions */
-const { expect } = require('chai');
+const { expect, assert } = require('chai');
 
 const feathers = require('@feathersjs/feathers');
 const express = require('@feathersjs/express');
 const memory = require('feathers-memory');
 const rp = require('request-promise');
+const SwaggerParser = require('swagger-parser');
 const swagger = require('../lib');
 
 describe('feathers-swagger', () => {
@@ -12,6 +13,27 @@ describe('feathers-swagger', () => {
     let server;
 
     before(done => {
+      const messageService = memory();
+      messageService.docs = {
+        description: 'A service to send and receive messages',
+        definition: {
+          'type': 'object',
+          'required': [
+            'text'
+          ],
+          'properties': {
+            'text': {
+              'type': 'string',
+              'description': 'The message text'
+            },
+            'userId': {
+              'type': 'string',
+              'description': 'The id of the user that sent the message'
+            }
+          }
+        }
+      };
+
       const app = express(feathers())
         .configure(express.rest())
         .configure(
@@ -24,7 +46,7 @@ describe('feathers-swagger', () => {
             idType: 'string'
           })
         )
-        .use('/messages', memory());
+        .use('/messages', messageService);
 
       server = app.listen(6776, () => done());
     });
@@ -50,6 +72,23 @@ describe('feathers-swagger', () => {
         const messagesIdParam = docs.paths['/messages/{id}'].get.parameters[0];
         expect(messagesIdParam.type).to.equal('string');
       });
+    });
+
+    it('check swagger document validity', () => {
+      let swaggerSpec;
+      return rp({
+        url: 'http://localhost:6776/docs',
+        json: true
+      }).then(docs => {
+        swaggerSpec = docs;
+        return SwaggerParser.validate(docs);
+      })
+        .then(api => {
+          expect(api).to.exist;
+        })
+        .catch(error => {
+          assert.fail(`${error.message}\n\nJSON:\n${JSON.stringify(swaggerSpec, undefined, 2)}`);
+        });
     });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -41,7 +41,8 @@ describe('feathers-swagger', () => {
             docsPath: '/docs',
             info: {
               title: 'A test',
-              description: 'A description'
+              description: 'A description',
+              version: '1.0.0'
             },
             idType: 'string'
           })


### PR DESCRIPTION
### Summary
Before starting to add openapi 3 support I though it would be good to release another 0.7 version, that outputs valid swagger v2.

* add test to validate the generated swagger specification (using [swagger-parser](https://www.npmjs.com/package/swagger-parser))
* include https://github.com/feathersjs-ecosystem/feathers-swagger/pull/89 to add version
* fix incorrect default basePath
* fix default empty externalDocs of tags

As I already stated, I would also help to maintain this repo.