### PR TITLE
Added typings for custom Swagger specfications generation.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 2.8
+// TypeScript Version: 2.9
 
 import { Request, Response } from 'express';
 import { Service } from '@feathersjs/feathers';
@@ -216,4 +216,13 @@ declare namespace feathersSwagger {
   }): void;
 
   function security(method: string, securities: Securities, security: UnknownObject[]): UnknownObject[];
+}
+
+declare module '@feathersjs/adapter-commons' {
+  interface AdapterService<T = any> {
+    /**
+     * Docs for Swagger specfications generation.
+     */
+    docs: feathersSwagger.ServiceSwaggerOptions;
+  }
 }


### PR DESCRIPTION
This PR adds typings for `docs` in the following example:

```ts
const messageService = memory();

  // `docs` will be typed correctly.
  messageService.docs = {
    // ...
  };
```