### PR TITLE
Added support for array `service.id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ __Options:__
 - `tags` (*optional*) - Give multiple tags
 - `model` (*optional*) - Override model that is parsed from path
 - `modelName` (*optional*) - Override modelName that is parsed from path
-- `idType` (*optional*) - The swagger type of ids used in paths for this service
+- `idType` (*optional*) - The swagger type of ids used in paths for this service. value can be an array of types when `service.id` is set to array.
 - `idNames` (*optional*) - Object with path parameter names, to customize the idName on operation / method level
   - `get`|`update`|`patch`|`remove` - name of the path parameter for the specific method, use service.id to change it for all
 - `definition`(also `schema` for openapi v3) (*optional*) - Swagger definition of the model of the service, will be merged into global definitions (with all additional generated definitions)

--- a/lib/openapi.js
+++ b/lib/openapi.js
@@ -168,6 +168,7 @@ class OpenApiGenerator {
     const pathObj = this.specs.paths;
     const basePath = `/${path}`;
     const multiOperations = doc.multi || this.config.defaults.multi;
+    const idSeparator = (service.options && service.options.idSeparator) || ',';
 
     this.applyDefinitionsToSpecs(service, model, modelName);
 
@@ -187,12 +188,12 @@ class OpenApiGenerator {
 
       let swaggerPath = path;
       if (methodIdName) {
-        swaggerPath += `/{${methodIdName}}`;
+        swaggerPath += `/${utils.idPathParameters(methodIdName, idSeparator)}`;
       }
 
       if (customMethod) {
         const withId = path.includes(':__feathersId');
-        swaggerPath = swaggerPath.replace(':__feathersId', `{${idName}}`);
+        swaggerPath = swaggerPath.replace(':__feathersId', utils.idPathParameters(idName, idSeparator));
         const generator = typeof this.config.defaults.operationGenerators.custom === 'function'
           ? this.config.defaults.operationGenerators.custom
           : this.operationDefaults.custom;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,3 +44,7 @@ exports.security = function security (method, securities, security) {
 
   return [];
 };
+
+exports.idPathParameters = function idPathParameters (idName, idSeparator) {
+  return `{${Array.isArray(idName) ? idName.join(`}${idSeparator}{`) : idName}}`;
+};

--- a/lib/v2/generator.js
+++ b/lib/v2/generator.js
@@ -1,6 +1,26 @@
 const AbstractApiGenerator = require('../openapi');
 const utils = require('../utils');
 
+function idPathParameters (idName, idType, description) {
+  const idNames = Array.isArray(idName) ? idName : [idName];
+  const idTypes = Array.isArray(idType) ? idType : [idType];
+  const params = [];
+
+  for (let i = 0; i < idNames.length; i++) {
+    const name = idNames[i];
+
+    params.push({
+      in: 'path',
+      name,
+      description,
+      type: idTypes[i] || idTypes[0],
+      required: true
+    });
+  }
+
+  return params;
+}
+
 class OpenApiV2Generator extends AbstractApiGenerator {
   getDefaultSpecs () {
     return {
@@ -63,13 +83,7 @@ class OpenApiV2Generator extends AbstractApiGenerator {
         return {
           tags,
           description: 'Retrieves a single resource with the given id from the service.',
-          parameters: [{
-            description: `ID of ${modelName} to return`,
-            in: 'path',
-            required: true,
-            name: idName,
-            type: idType
-          }],
+          parameters: idPathParameters(idName, idType, `ID of ${modelName} to return`),
           responses: {
             200: {
               description: 'success',
@@ -127,20 +141,14 @@ class OpenApiV2Generator extends AbstractApiGenerator {
         return {
           tags,
           description: 'Updates the resource identified by id using data.',
-          parameters: [{
-            description: `ID of ${modelName} to return`,
-            in: 'path',
-            required: true,
-            name: idName,
-            type: idType
-          }, {
+          parameters: idPathParameters(idName, idType, `ID of ${modelName} to return`).concat([{
             in: 'body',
             name: 'body',
             required: true,
             schema: {
               $ref: `#/definitions/${refs.updateRequest}`
             }
-          }],
+          }]),
           responses: {
             200: {
               description: 'success',
@@ -198,20 +206,14 @@ class OpenApiV2Generator extends AbstractApiGenerator {
         return {
           tags,
           description: 'Updates the resource identified by id using data.',
-          parameters: [{
-            description: `ID of ${modelName} to update`,
-            in: 'path',
-            required: true,
-            name: idName,
-            type: idType
-          }, {
+          parameters: idPathParameters(idName, idType, `ID of ${modelName} to update`).concat([{
             in: 'body',
             name: 'body',
             required: true,
             schema: {
               $ref: `#/definitions/${refs.patchRequest}`
             }
-          }],
+          }]),
           responses: {
             200: {
               description: 'success',
@@ -271,13 +273,7 @@ class OpenApiV2Generator extends AbstractApiGenerator {
         return {
           tags,
           description: 'Removes the resource with id.',
-          parameters: [{
-            description: `ID of ${modelName} to remove`,
-            in: 'path',
-            required: true,
-            name: idName,
-            type: idType
-          }],
+          parameters: idPathParameters(idName, idType, `ID of ${modelName} to remove`),
           responses: {
             200: {
               description: 'success',
@@ -328,7 +324,6 @@ class OpenApiV2Generator extends AbstractApiGenerator {
         const customDoc = {
           tags,
           description: `A custom ${method} method.`,
-          parameters: [],
           responses: {
             200: {
               description: 'success'
@@ -345,15 +340,7 @@ class OpenApiV2Generator extends AbstractApiGenerator {
           security: utils.security(method, securities, security)
         };
 
-        if (withId) {
-          customDoc.parameters[0] = {
-            description: `ID of ${modelName}`,
-            in: 'path',
-            required: true,
-            name: idName,
-            type: idType
-          };
-        }
+        customDoc.parameters = withId ? idPathParameters(idName, idType, `ID of ${modelName}`) : [];
 
         if (['post', 'put', 'patch'].includes(httpMethod)) {
           const refRequestName = `${method}Request`;

--- a/lib/v3/generator.js
+++ b/lib/v3/generator.js
@@ -31,6 +31,28 @@ function jsonSchemaRef (ref) {
   };
 }
 
+function idPathParameters (idName, idType, description) {
+  const idNames = Array.isArray(idName) ? idName : [idName];
+  const idTypes = Array.isArray(idType) ? idType : [idType];
+  const params = [];
+
+  for (let i = 0; i < idNames.length; i++) {
+    const name = idNames[i];
+
+    params.push({
+      in: 'path',
+      name,
+      description,
+      schema: {
+        type: idTypes[i] || idTypes[0]
+      },
+      required: true
+    });
+  }
+
+  return params;
+}
+
 class OpenApiV3Generator extends AbstractApiGenerator {
   getDefaultSpecs () {
     return {
@@ -106,15 +128,7 @@ class OpenApiV3Generator extends AbstractApiGenerator {
         return {
           tags,
           description: 'Retrieves a single resource with the given id from the service.',
-          parameters: [{
-            description: `ID of ${modelName} to return`,
-            in: 'path',
-            required: true,
-            name: idName,
-            schema: {
-              type: idType
-            }
-          }],
+          parameters: idPathParameters(idName, idType, `ID of ${modelName} to return`),
           responses: {
             200: {
               description: 'success',
@@ -160,15 +174,7 @@ class OpenApiV3Generator extends AbstractApiGenerator {
         return {
           tags,
           description: 'Updates the resource identified by id using data.',
-          parameters: [{
-            description: `ID of ${modelName} to update`,
-            in: 'path',
-            required: true,
-            name: idName,
-            schema: {
-              type: idType
-            }
-          }],
+          parameters: idPathParameters(idName, idType, `ID of ${modelName} to update`),
           requestBody: {
             required: true,
             content: jsonSchemaRef(refs.updateRequest)
@@ -219,15 +225,7 @@ class OpenApiV3Generator extends AbstractApiGenerator {
         return {
           tags,
           description: 'Updates the resource identified by id using data.',
-          parameters: [{
-            description: `ID of ${modelName} to update`,
-            in: 'path',
-            required: true,
-            name: idName,
-            schema: {
-              type: idType
-            }
-          }],
+          parameters: idPathParameters(idName, idType, `ID of ${modelName} to update`),
           requestBody: {
             required: true,
             content: jsonSchemaRef(refs.patchRequest)
@@ -278,15 +276,7 @@ class OpenApiV3Generator extends AbstractApiGenerator {
         return {
           tags,
           description: 'Removes the resource with id.',
-          parameters: [{
-            description: `ID of ${modelName} to remove`,
-            in: 'path',
-            required: true,
-            name: idName,
-            schema: {
-              type: idType
-            }
-          }],
+          parameters: idPathParameters(idName, idType, `ID of ${modelName} to remove`),
           responses: {
             200: {
               description: 'success',
@@ -329,7 +319,6 @@ class OpenApiV3Generator extends AbstractApiGenerator {
         const customDoc = {
           tags,
           description: `A custom ${method} method.`,
-          parameters: [],
           responses: {
             200: {
               description: 'success'
@@ -345,15 +334,7 @@ class OpenApiV3Generator extends AbstractApiGenerator {
         };
 
         if (withId) {
-          customDoc.parameters[0] = {
-            description: `ID of ${modelName}`,
-            in: 'path',
-            required: true,
-            name: idName,
-            schema: {
-              type: idType
-            }
-          };
+          customDoc.parameters = withId ? idPathParameters(idName, idType, `ID of ${modelName}`) : [];
         }
 
         if (['post', 'put', 'patch'].includes(httpMethod)) {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-expressions */
 const { expect } = require('chai');
-const { operation, tag, security } = require('../lib/utils');
+const { operation, tag, security, idPathParameters } = require('../lib/utils');
 
 describe('util tests', () => {
   describe('operation', () => {
@@ -129,6 +129,24 @@ describe('util tests', () => {
 
     it('should return security definitions array when all methods should be secured', () => {
       expect(security('create', ['all'], securityDefinitions)).to.equals(securityDefinitions);
+    });
+  });
+
+  describe('idPathParameters', () => {
+    it('should return id path parameters when idName is string', () => {
+      expect(idPathParameters('id', ',')).to.deep.equals('{id}');
+    });
+
+    it('should return id path parameters when idName is array', () => {
+      expect(idPathParameters(['id'], ',')).to.deep.equals('{id}');
+    });
+
+    it('should return id path parameters when idName is array with multiple items', () => {
+      expect(idPathParameters(['firstId', 'secondId'], ',')).to.deep.equals('{firstId},{secondId}');
+    });
+
+    it('should return id path parameters when idName is array with multiple items and custom idSeparator', () => {
+      expect(idPathParameters(['firstId', 'secondId'], '|')).to.deep.equals('{firstId}|{secondId}');
     });
   });
 });

--- a/test/v3/generator.test.js
+++ b/test/v3/generator.test.js
@@ -974,6 +974,55 @@ describe('openopi v3 generator', function () {
       expect(specs.paths['/message/{rid}'].delete.parameters[0].name).to.equal('rid');
     });
 
+    describe('array service.id', function () {
+      it('array service.id should be consumed', function () {
+        const specs = {};
+        const gen = new OpenApi3Generator(specs, swaggerOptions);
+        const service = memory();
+        service.options.id = ['firstId', 'secondId'];
+        service.docs = {
+          definition: messageDefinition
+        };
+
+        gen.addService(service, 'message');
+
+        expect(specs.paths['/message/{firstId},{secondId}'].get.parameters[0].schema.type).to.equal('integer');
+        expect(specs.paths['/message/{firstId},{secondId}'].get.parameters[1].schema.type).to.equal('integer');
+      });
+
+      it('array service.id should be consumed', function () {
+        const specs = {};
+        const gen = new OpenApi3Generator(specs, swaggerOptions);
+        const service = memory();
+        service.options.id = ['firstId', 'secondId'];
+        service.docs = {
+          idType: ['string', 'integer'],
+          definition: messageDefinition
+        };
+
+        gen.addService(service, 'message');
+
+        expect(specs.paths['/message/{firstId},{secondId}'].get.parameters[0].schema.type).to.equal('string');
+        expect(specs.paths['/message/{firstId},{secondId}'].get.parameters[1].schema.type).to.equal('integer');
+      });
+
+      it('array service.id with custom service.idSeparator should be consumed', function () {
+        const specs = {};
+        const gen = new OpenApi3Generator(specs, swaggerOptions);
+        const service = memory();
+        service.options.id = ['firstId', 'secondId'];
+        service.options.idSeparator = '|';
+        service.docs = {
+          definition: messageDefinition
+        };
+
+        gen.addService(service, 'message');
+
+        expect(specs.paths['/message/{firstId}|{secondId}'].get.parameters[0].schema.type).to.equal('integer');
+        expect(specs.paths['/message/{firstId}|{secondId}'].get.parameters[1].schema.type).to.equal('integer');
+      });
+    });
+
     describe('overwriteTagSpec', function () {
       it('nothing should be overwritten by default', function () {
         specs.tags = [

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -159,7 +159,7 @@ declare namespace feathersSwagger {
     tags?: string[];
     model?: string;
     modelName?: string;
-    idType?: string;
+    idType?: string | string[];
     idNames?: {
       get?: string;
       update?: string;

--- a/types/test.ts
+++ b/types/test.ts
@@ -252,6 +252,13 @@ const serviceEmptyRefs: ServiceSwaggerAddon = {
   }
 };
 
+// array idType
+const serviceIdTypeArray: ServiceSwaggerAddon = {
+  docs: {
+    idType: ['string'],
+  }
+};
+
 // empty docs object
 const serviceEmpty: ServiceSwaggerAddon = {
   docs: {}


### PR DESCRIPTION
Added support for array `service.id` to support the composite PK feature in [feathers-objection](https://github.com/feathersjs-ecosystem/feathers-objection) & [feathers-cassandra](https://github.com/feathersjs-ecosystem/feathers-cassandra).

`service.docs.idType` option can now be also set to an array of types for the parameters in `service.id`.

`service.options.idSeparator` (default: `,`) is being used to separate the ID fields in the path, e.g. `/users/{firstId},{secondId}`.

See issue https://github.com/feathersjs-ecosystem/feathers-swagger/issues/194 for more details.