### PR TITLE
feat: allow disabling of methods from defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ __Options:__
   - `getOperationArgs({ service, path, config, apiPath, version })` - method to generate args that the methods for operations will consume, can also customize default tag and model generation
   - `getOperationsRefs(model, service)` - method to generate refs that the methods for operations will consume, see service.docs.refs option
   - `schemasGenerator(service, model, modelName, schemas)` - method to generate the json schemas for a service
-  - `operationGenerators` - generator functions to fully customize specification generation for operations
-    - `find`|`get`|`create`|`update`|`patch`|`remove` - generator function for the specific operation
+  - `operationGenerators` - generator functions to fully customize specification generation for operations. To disable the generation of a method return false.
+    - `find`|`get`|`create`|`update`|`patch`|`remove` - generator function for the specific operation.
     - `updateMulti`|`patchMulti`|`removeMulti` - generator function for the "multi mode" version of the specific operation
     - `custom` - generator function for all custom operations
   - `operations` - objects with defaults for the operations, with [path support to update nested structures](#path-support-to-update-nested-structures)
-    - `find`|`get`|`create`|`update`|`patch`|`remove`|`nameOfCustomMethod` - to change defaults of a specific operation
-    - `updateMulti`|`patchMulti`|`removeMulti` - to change defaults for "multi mode" of a specific operation
+    - `find`|`get`|`create`|`update`|`patch`|`remove`|`nameOfCustomMethod` - to change defaults of a specific operation. To disable the generation set to false.
+    - `updateMulti`|`patchMulti`|`removeMulti` - to change defaults for "multi mode" of a specific operation. To disable the generation set to false.
     - `all` - to change defaults of all operations
   - `multi` - array with operations that should also be available in "multi mode", use `'all'` to enable for all operations that support it
 

--- a/lib/openapi.js
+++ b/lib/openapi.js
@@ -205,6 +205,10 @@ class OpenApiGenerator {
         defaults = generator(methodIdName ? { ...defaultArgumentObject, idName: methodIdName } : defaultArgumentObject);
       }
 
+      if (defaults === false || this.config.defaults.operations[method] === false) {
+        return;
+      }
+
       if (typeof this.config.defaults.operations[method] === 'object') {
         assignWithSet(defaults, this.config.defaults.operations[method]);
       }

--- a/test/v3/generator.test.js
+++ b/test/v3/generator.test.js
@@ -505,6 +505,9 @@ describe('openopi v3 generator', function () {
                     description: 'Only description'
                   };
                 },
+                get (options) {
+                  return false;
+                },
                 custom (options) {
                   return {
                     description: 'Only custom description'
@@ -524,6 +527,7 @@ describe('openopi v3 generator', function () {
             tags: [],
             security: []
           });
+          expect(specs.paths['/message/{id}']).to.not.exist;
           expect(specs.paths['/message/custom'].post).to.deep.equal({
             parameters: [],
             responses: {},
@@ -545,6 +549,7 @@ describe('openopi v3 generator', function () {
                 find: {
                   description: 'Other description for find'
                 },
+                get: false,
                 customMethod: {
                   description: 'Description for specific custom method'
                 }
@@ -555,6 +560,7 @@ describe('openopi v3 generator', function () {
           gen.addService(service, 'message');
 
           expect(specs.paths['/message'].get.description).to.equal('Other description for find');
+          expect(specs.paths['/message/{id}']).to.not.exist;
           expect(specs.paths['/message/custom'].post.description).to.equal('Description for specific custom method');
         });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -63,7 +63,7 @@ type FnOperationSpecsGeneratorOptions = {
 } & UnknownObject;
 
 interface FnOperationSpecsGenerator {
-  (options: FnOperationSpecsGeneratorOptions): UnknownObject;
+  (options: FnOperationSpecsGeneratorOptions): OperationConfig;
 }
 
 interface FnCustomOperationSpecsGenerator {
@@ -71,7 +71,7 @@ interface FnCustomOperationSpecsGenerator {
     method: string,
     httpMethod: 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head' | 'options' | 'connect' | 'trace',
     withId: boolean,
-  }): UnknownObject;
+  }): OperationConfig;
 }
 
 interface ExternalDocs {
@@ -94,6 +94,8 @@ type SpecsObject = {
 } & UnknownObject;
 
 type OpenApiVersion = 2 | 3;
+
+type OperationConfig = UnknownObject | false;
 
 declare namespace feathersSwagger {
   interface SwaggerInitOptions {
@@ -131,17 +133,17 @@ declare namespace feathersSwagger {
         custom?: FnCustomOperationSpecsGenerator;
       }
       operations?: {
-        find?: UnknownObject;
-        get?: UnknownObject;
-        create?: UnknownObject;
-        update?: UnknownObject;
-        patch?: UnknownObject;
-        remove?: UnknownObject;
-        updateMulti?: UnknownObject;
-        patchMulti?: UnknownObject;
-        removeMulti?: UnknownObject;
+        find?: OperationConfig;
+        get?: OperationConfig;
+        create?: OperationConfig;
+        update?: OperationConfig;
+        patch?: OperationConfig;
+        remove?: OperationConfig;
+        updateMulti?: OperationConfig;
+        patchMulti?: OperationConfig;
+        removeMulti?: OperationConfig;
         all?: UnknownObject;
-        [customMethod: string]: UnknownObject | undefined;
+        [customMethod: string]: OperationConfig | undefined;
       }
       multi?: MultiOperations;
     };
@@ -173,17 +175,17 @@ declare namespace feathersSwagger {
     overwriteTagSpec?: boolean;
     multi?: MultiOperations;
     operations?: {
-      find?: UnknownObject | false;
-      get?: UnknownObject | false;
-      create?: UnknownObject | false;
-      update?: UnknownObject | false;
-      patch?: UnknownObject | false;
-      remove?: UnknownObject | false;
-      updateMulti?: UnknownObject | false;
-      patchMulti?: UnknownObject | false;
-      removeMulti?: UnknownObject | false;
+      find?: OperationConfig;
+      get?: OperationConfig;
+      create?: OperationConfig;
+      update?: OperationConfig;
+      patch?: OperationConfig;
+      remove?: OperationConfig;
+      updateMulti?: OperationConfig;
+      patchMulti?: OperationConfig;
+      removeMulti?: OperationConfig;
       all?: UnknownObject;
-      [customOperation: string]: UnknownObject | false | undefined;
+      [customOperation: string]: OperationConfig | undefined;
     };
   }
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType } from 'tsd';
+import { expectType, expectError } from 'tsd';
 import swagger, {
   ServiceSwaggerAddon,
   SwaggerService,
@@ -135,7 +135,7 @@ swagger({
   },
 });
 
-// apiVersion 3
+// apiVersion 3, operations default with false
 swagger({
   specs: {
     info: {
@@ -145,7 +145,49 @@ swagger({
     }
   },
   openApiVersion: 3,
+  defaults: {
+    operations: {
+      find: false,
+      get: false,
+      create: false,
+      patch: false,
+      update: false,
+      remove: false,
+      patchMulti: false,
+      updateMulti: false,
+      removeMulti: false,
+      customMethod: false,
+    },
+    operationGenerators: {
+      find() { return false },
+      get() { return false },
+      create() { return false },
+      patch() { return false },
+      update() { return false },
+      remove() { return false },
+      patchMulti() { return false },
+      updateMulti() { return false },
+      removeMulti() { return false },
+      custom() { return false },
+    }
+  }
 });
+
+// operation default for all not allowed with false
+expectError(swagger({
+  specs: {
+    info: {
+      description: 'My test description',
+      title: 'Title of Tests',
+      version: '1.0.0'
+    }
+  },
+  defaults: {
+    operations: {
+      all: false,
+    }
+  }
+}));
 
 // empty sub objects
 swagger({


### PR DESCRIPTION
### Summary

* allow disabling of methods via the option `defaults.operations` by setting it to false for a method.
* allow disabling of methods by returning null from an operation generator set at `defaults.operationGenerators`

closes #214 