### PR TITLE
Include required in pagination result

### DIFF
--- a/lib/v3/generator.js
+++ b/lib/v3/generator.js
@@ -468,6 +468,7 @@ class OpenApiV3Generator extends AbstractApiGenerator {
         this.specs.components.schemas[pagination] = {
           title: `${modelName} pagination result`,
           type: 'object',
+          required: true,
           properties: {
             total: { type: 'integer' },
             limit: { type: 'integer' },


### PR DESCRIPTION
### Summary

I was using https://github.com/acacode/swagger-typescript-api to generate a TypeScript client based on the swagger file created by `feathers-swagger` and one issue I ran across is that pagination results had all optional properties.

Like this

```ts
/** Company pagination result */
export interface CompanyPaginationType {
  total?: number;
  limit?: number;
  skip?: number;
  data?: CompanyListType;
}
```

I believe this is not correct, so this PR address that and the outputted type looks like this now


```ts
/** Company pagination result */
export interface CompanyPaginationType {
  total: number;
  limit: number;
  skip: number;
  data: CompanyListType;
}
```
