### PR TITLE
Remove allowedDefaultRefs

### DIFF
--- a/docs/custom-methods.md
+++ b/docs/custom-methods.md
@@ -103,6 +103,46 @@ app.use('some', new SomeService(options), {
 
 <!-- tabs:end -->
 
+<!-- tabs:start -->
+### **How to document custom methods**
+
+`feathers-swagger` allows you to pass a `Request` and `Response` schema to document what your custom method expects and returns. 
+
+```typescript
+export const userApproveRequest = Type.Object(
+  {
+    userMessage: Type.String({
+      description: 'A message by the user'
+    })
+  },
+  {
+    $id: 'userApproveRequest',
+    additionalProperties: false
+  }
+)
+
+export const userApproveResponse = Type.Object(
+  {
+   successMessage: Type.String()
+  },
+  {
+    $id: 'userApproveResponse',
+    additionalProperties: false
+  }
+)
+```
+
+In `createSwaggerServiceOptions` you can pass these new schemas 
+
+```typescript
+ docs: createSwaggerServiceOptions({
+	schemas: {..., userApproveRequest, userApproveResponse},
+    ...
+ })
+```
+
+<!-- tabs:end -->
+
 ## Example
 
 Check out the [example](/examples/custom_methods.md) to see it in action. 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -50,28 +50,6 @@ exports.idPathParameters = function idPathParameters (idName, idSeparator) {
   return `{${Array.isArray(idName) ? idName.join(`}${idSeparator}{`) : idName}}`;
 };
 
-const allowedDefaultRefs = [
-  'findResponse',
-  'getResponse',
-  'createRequest',
-  'createResponse',
-  'createMultiRequest',
-  'createMultiResponse',
-  'updateRequest',
-  'updateResponse',
-  'updateMultiRequest',
-  'updateMultiResponse',
-  'patchRequest',
-  'patchResponse',
-  'patchMultiRequest',
-  'patchMultiResponse',
-  'removeResponse',
-  'removeMultiResponse',
-  'filterParameter',
-  'sortParameter',
-  'queryParameters'
-];
-
 exports.defaultTransformSchema = function defaultTransformSchema (schema) {
   const allowedProperties = pick(schema, [
     'title',
@@ -235,9 +213,7 @@ exports.createSwaggerServiceOptions = function createSwaggerServiceOptions ({ sc
     const schemaName = schema.$id;
     if (schemaName) {
       serviceDocs.schemas[schemaName] = transformSchemaFn(schema);
-      if (allowedDefaultRefs.includes(key)) {
-        serviceDocs.refs[key] = schemaName;
-      }
+      serviceDocs.refs[key] = schemaName;
     }
   });
 


### PR DESCRIPTION
### Summary

Currently, if you wish to document a custom method. You have to manually link the ref like this

```ts
createSwaggerServiceOptions({
  schemas: { userApproveSchema }
  docs: {
    refs: {
      userApproveRequest: userApproveSchema.$id
    }
  }
})
```

This PR removes the check that makes that necessary, and custom method `Request` and `Response` schemas can be referenced automatically. 
