### PR TITLE
An/multi create fix

### DIFF
--- a/lib/openapi.js
+++ b/lib/openapi.js
@@ -12,6 +12,7 @@ const defaultMethods = [
   { operation: 'update', method: 'update', id: true, httpMethod: 'put', multi: false },
   { operation: 'patch', method: 'patch', id: true, httpMethod: 'patch', multi: false },
   { operation: 'remove', method: 'remove', id: true, httpMethod: 'delete', multi: false },
+  { operation: 'createMulti', method: 'create', id: false, httpMethod: 'post', multi: true },
   { operation: 'updateMulti', method: 'update', id: false, httpMethod: 'put', multi: true },
   { operation: 'patchMulti', method: 'patch', id: false, httpMethod: 'patch', multi: true },
   { operation: 'removeMulti', method: 'remove', id: false, httpMethod: 'delete', multi: true }
@@ -48,7 +49,8 @@ function ignoreService (service, path, includeConfig, ignoreConfig) {
 
 function determineMultiOperations (service) {
   if (service.options && service.options.multi) {
-    return ['remove', 'update', 'patch', 'create'].filter((operation) => _.isFunction(service[operation]));
+    const operations = service.options.multi === true ? ['remove', 'update', 'patch', 'create'] : service.options.multi
+    return operations.filter((operation) => _.isFunction(service[operation]));
   }
 
   return [];

--- a/lib/openapi.js
+++ b/lib/openapi.js
@@ -12,7 +12,6 @@ const defaultMethods = [
   { operation: 'update', method: 'update', id: true, httpMethod: 'put', multi: false },
   { operation: 'patch', method: 'patch', id: true, httpMethod: 'patch', multi: false },
   { operation: 'remove', method: 'remove', id: true, httpMethod: 'delete', multi: false },
-  { operation: 'createMulti', method: 'create', id: false, httpMethod: 'post', multi: true },
   { operation: 'updateMulti', method: 'update', id: false, httpMethod: 'put', multi: true },
   { operation: 'patchMulti', method: 'patch', id: false, httpMethod: 'patch', multi: true },
   { operation: 'removeMulti', method: 'remove', id: false, httpMethod: 'delete', multi: true }
@@ -49,7 +48,7 @@ function ignoreService (service, path, includeConfig, ignoreConfig) {
 
 function determineMultiOperations (service) {
   if (service.options && service.options.multi) {
-    const operations = service.options.multi === true ? ['remove', 'update', 'patch', 'create'] : service.options.multi
+    const operations = service.options.multi === true ? serviceMethods : service.options.multi;
     return operations.filter((operation) => _.isFunction(service[operation]));
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -193,7 +193,7 @@ exports.createSwaggerServiceOptions = function createSwaggerServiceOptions ({ sc
         [baseSchemeName]: transformSchemaFn(resultSchema),
         [listSchemaName]: {
           type: 'array',
-          items: { $ref: `#/components/schemas/${baseSchemeName}` }
+          items: { $ref: `#/components/schemas/${baseSchemeName}Data` }
         }
       };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -50,28 +50,6 @@ exports.idPathParameters = function idPathParameters (idName, idSeparator) {
   return `{${Array.isArray(idName) ? idName.join(`}${idSeparator}{`) : idName}}`;
 };
 
-const allowedDefaultRefs = [
-  'findResponse',
-  'getResponse',
-  'createRequest',
-  'createResponse',
-  'createMultiRequest',
-  'createMultiResponse',
-  'updateRequest',
-  'updateResponse',
-  'updateMultiRequest',
-  'updateMultiResponse',
-  'patchRequest',
-  'patchResponse',
-  'patchMultiRequest',
-  'patchMultiResponse',
-  'removeResponse',
-  'removeMultiResponse',
-  'filterParameter',
-  'sortParameter',
-  'queryParameters'
-];
-
 exports.defaultTransformSchema = function defaultTransformSchema (schema) {
   const allowedProperties = pick(schema, [
     'title',
@@ -193,7 +171,7 @@ exports.createSwaggerServiceOptions = function createSwaggerServiceOptions ({ sc
         [baseSchemeName]: transformSchemaFn(resultSchema),
         [listSchemaName]: {
           type: 'array',
-          items: { $ref: `#/components/schemas/${baseSchemeName}Data` }
+          items: { $ref: `#/components/schemas/${baseSchemeName}` }
         }
       };
 
@@ -250,9 +228,7 @@ exports.createSwaggerServiceOptions = function createSwaggerServiceOptions ({ sc
     const schemaName = schema.$id;
     if (schemaName) {
       serviceDocs.schemas[schemaName] = transformSchemaFn(schema);
-      if (allowedDefaultRefs.includes(key)) {
-        serviceDocs.refs[key] = schemaName;
-      }
+      serviceDocs.refs[key] = schemaName;
     }
   });
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -201,8 +201,15 @@ exports.createSwaggerServiceOptions = function createSwaggerServiceOptions ({ sc
 
       if (dataSchema) {
         const dataSchemeName = dataSchema.$id || `${baseSchemeName}Data`;
+        const dataListSchemeName = `${dataSchemeName}List`;
+
         serviceDocs.schemas[dataSchemeName] = transformSchemaFn(dataSchema);
+        serviceDocs.schemas[dataListSchemeName] = {
+          type: 'array',
+          items: { $ref: `#/components/schemas/${dataSchemeName}` }
+        };
         serviceDocs.refs.createRequest = dataSchemeName;
+        serviceDocs.refs.createMultiRequest = { refs: [dataSchemeName, dataListSchemeName], type: 'oneOf' };
         serviceDocs.refs.updateRequest = dataSchemeName;
       }
 
@@ -218,8 +225,16 @@ exports.createSwaggerServiceOptions = function createSwaggerServiceOptions ({ sc
 
       if (patchSchema) {
         const patchSchemaName = patchSchema.$id || `${baseSchemeName}PatchData`;
+        const patchListSchemeName = `${patchSchemaName}List`;
+
         serviceDocs.schemas[patchSchemaName] = transformSchemaFn(patchSchema);
+        serviceDocs.schemas[patchListSchemeName] = {
+          type: 'array',
+          items: { $ref: `#/components/schemas/${patchSchemaName}` }
+        };
+
         serviceDocs.refs.patchRequest = patchSchemaName;
+        serviceDocs.refs.patchMultiRequest = patchListSchemeName;
       }
 
       if (!docs || !docs.model) {

--- a/lib/v3/generator.js
+++ b/lib/v3/generator.js
@@ -468,6 +468,7 @@ class OpenApiV3Generator extends AbstractApiGenerator {
         this.specs.components.schemas[pagination] = {
           title: `${modelName} pagination result`,
           type: 'object',
+          required: true,
           properties: {
             total: { type: 'integer' },
             limit: { type: 'integer' },

--- a/lib/v3/generator.js
+++ b/lib/v3/generator.js
@@ -104,7 +104,7 @@ class OpenApiV3Generator extends AbstractApiGenerator {
       getResponse: model,
       createRequest: model,
       createResponse: model,
-      createMultiRequest: { refs: [model, modelList], type: 'oneOf' },
+      createMultiRequest: { refs: [`${model}Data`, modelList], type: 'oneOf' },
       createMultiResponse: { refs: [model, modelList], type: 'oneOf' },
       updateRequest: model,
       updateResponse: model,
@@ -264,6 +264,30 @@ class OpenApiV3Generator extends AbstractApiGenerator {
             }
           },
           security: utils.security('update', securities, security)
+        };
+      },
+      createMulti ({ tags, security, securities, refs }) {
+        return {
+          tags,
+          description: 'Creates one or multiple resources.',
+          parameters: [],
+          requestBody: {
+            required: true,
+            content: jsonSchemaRef(refs.createMultiRequest)
+          },
+          responses: {
+            200: {
+              description: 'success',
+              content: jsonSchemaRef(refs.createMultiResponse)
+            },
+            401: {
+              description: 'not authenticated'
+            },
+            500: {
+              description: 'general error'
+            }
+          },
+          security: utils.security('create', securities, security)
         };
       },
       updateMulti ({ tags, security, securities, refs }) {

--- a/lib/v3/generator.js
+++ b/lib/v3/generator.js
@@ -219,7 +219,7 @@ class OpenApiV3Generator extends AbstractApiGenerator {
         const multi = multiOperations.includes('create');
         return {
           tags,
-          description: 'Creates a new resource with data.',
+          description: multi ? 'Creates one or multiple resources.' : 'Creates a new resource with data.',
           requestBody: {
             required: true,
             content: multi ? jsonSchemaRef(refs.createMultiRequest) : jsonSchemaRef(refs.createRequest)

--- a/test/v3/expected-memory-spec-multi-only.json
+++ b/test/v3/expected-memory-spec-multi-only.json
@@ -6,7 +6,7 @@
   "paths": {
     "/message": {
       "post": {
-        "description": "Creates a new resource with data.",
+        "description": "Creates one or multiple resources.",
         "parameters": [],
         "requestBody": {
           "content": {

--- a/test/v3/expected-memory-spec-pagination-find.json
+++ b/test/v3/expected-memory-spec-pagination-find.json
@@ -17,6 +17,7 @@
         "type": "array"
       },
       "messagePagination": {
+        "required": true,
         "title": "message pagination result",
         "type": "object",
         "properties": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -150,7 +150,6 @@ declare namespace feathersSwagger {
         update?: FnOperationSpecsGenerator;
         patch?: FnOperationSpecsGenerator;
         remove?: FnOperationSpecsGenerator;
-        createMulti?: FnOperationSpecsGenerator;
         updateMulti?: FnOperationSpecsGenerator;
         patchMulti?: FnOperationSpecsGenerator;
         removeMulti?: FnOperationSpecsGenerator;
@@ -163,7 +162,6 @@ declare namespace feathersSwagger {
         update?: OperationConfig;
         patch?: OperationConfig;
         remove?: OperationConfig;
-        createMulti?: OperationConfig;
         updateMulti?: OperationConfig;
         patchMulti?: OperationConfig;
         removeMulti?: OperationConfig;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -150,6 +150,7 @@ declare namespace feathersSwagger {
         update?: FnOperationSpecsGenerator;
         patch?: FnOperationSpecsGenerator;
         remove?: FnOperationSpecsGenerator;
+        createMulti?: FnOperationSpecsGenerator;
         updateMulti?: FnOperationSpecsGenerator;
         patchMulti?: FnOperationSpecsGenerator;
         removeMulti?: FnOperationSpecsGenerator;
@@ -162,6 +163,7 @@ declare namespace feathersSwagger {
         update?: OperationConfig;
         patch?: OperationConfig;
         remove?: OperationConfig;
+        createMulti?: OperationConfig;
         updateMulti?: OperationConfig;
         patchMulti?: OperationConfig;
         removeMulti?: OperationConfig;


### PR DESCRIPTION
### Summary

feathers-swagger would handle `multi: ['create']` by using the base schema type. Which would be not ideal if you have a more narrow create schema. This PR is my attempt at correcting that.

### Other Information

Would appreciate letting me know if anything here could use fixes.

My other [PR](https://github.com/feathersjs-ecosystem/feathers-swagger/pull/254) is in here as well, I can remove it if needed. Ideally both can be merged together here.
