### PR TITLE
fix(deps): add missing optional peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,22 @@
   "dependencies": {
     "lodash": "^4.17.21"
   },
+  "peerDependencies": {
+    "swagger-ui-dist": ">=4.9.0",
+    "koa-static": "^5.0.0",
+    "koa-mount": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "swagger-ui-dist": {
+      "optional": true
+    },
+    "koa-static": {
+      "optional": true
+    },
+    "koa-mount": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@feathersjs/express": "^5.0.12",
     "@feathersjs/feathers": "^5.0.12",


### PR DESCRIPTION
### Summary

A couple of optional peer dependencies were not declared in the package.json. This prevents compatibility with modern versions of yarn, since yarn will block access to undecalred dependencies.

This adds the missing peer dependencies and marks them as optional so they only need to be installed when actually required

I've only tested with koa. It is possible that other setups might require similar peer dependencies that I did not have problems with. However a quick look at the documentation did not mention other peer dependencies in the installation section

- [x] Tell us about the problem your pull request is solving.
- [x] Are there any open issues that are related to this? - No
- [x] Is this PR dependent on PRs in other repos? - No
