### PR TITLE
fix: don't mutate original schemas

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,5 @@
 const { assignWithSet } = require('./helpers');
-const { omit, pick } = require('lodash');
+const { omit, pick, cloneDeep} = require('lodash');
 
 exports.tag = function tag (name, options = {}) {
   const result = {
@@ -165,9 +165,10 @@ function determineSchemaPrefix (schemas) {
   return undefined;
 }
 
-exports.createSwaggerServiceOptions = function createSwaggerServiceOptions ({ schemas, docs, transformSchema }) {
+exports.createSwaggerServiceOptions = function createSwaggerServiceOptions ({ schemas: originalSchemas, docs, transformSchema }) {
   const serviceDocs = { schemas: {}, refs: {} };
   const transformSchemaFn = transformSchema || exports.defaultTransformSchema;
+  const schemas = cloneDeep(originalSchemas)
 
   let unspecificSchemas;
   const prefix = determineSchemaPrefix(schemas);


### PR DESCRIPTION
### Summary

Swagger mutates schemas internally, ~this caused a problem for me where it modified my `Type.Date()` into a `Type.String()`~

EDIT: My issue was caused by a poor patch I had made. Non the less, I think the change is still valid. As the `defaultTransformSchema` function does mutate as well.


### Other Information

This shouldn't impact anyone in a negative way, my Swagger file did not change after the modification.